### PR TITLE
Quotes import URL in generated CSS.

### DIFF
--- a/css/sleepy.css
+++ b/css/sleepy.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic);
+@import url('http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic');
 /* imports */
 /* @import url("shell.css"); */
 /* namespaces */

--- a/css/teibp.css
+++ b/css/teibp.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic);
+@import url('http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic');
 /* imports */
 /* @import url("shell.css"); */
 /* namespaces */

--- a/css/terminal.css
+++ b/css/terminal.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic);
+@import url('http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Gentium+Book+Basic:400,400italic,700,700italic');
 /* imports */
 /* @import url("shell.css"); */
 /* namespaces */


### PR DESCRIPTION
The fix in 9025879f41bd993588816ef290fab695a218dde4 means that the CSS imports
are also quoted in the generated CSS files. Running the makecss script on the
repo will show these as modified by Git. This simply updates those generated
CSS files to include the quotes, so these files aren't shown as modified any
time someone makes CSS files.
