### PR TITLE
Give a name to the catch-all template

### DIFF
--- a/content/teibp.xsl
+++ b/content/teibp.xsl
@@ -97,7 +97,7 @@
         Existing @xml:id attributes are retained unchanged.</xd:p>
     </xd:desc>
   </xd:doc>
-  <xsl:template match="*"> 
+  <xsl:template match="*" name="teibp-default">
     <xsl:element name="{local-name()}">
       <xsl:apply-templates select="@*"/>
       <xsl:call-template name="addID"/>


### PR DESCRIPTION
The ability to invoke the default TEI-Bp template makes it possible
to overload the transformation of an element without having to copy
the existing code for that element.

For example, one can overload the default XSLT code for `<l>` adding the
following code to custom.xsl:

```
<xsl:template match="tei:l">
    <div>
        <xsl:call-template name="teibp-default"/>

        <span class="linenum"> [<xsl:value-of select="@n"/>]</span>
    </div>
</xsl:template>
```
