### PR TITLE
Comment out link to teibp.less, which no longer exists, and uncomment link to teibp.css

### DIFF
--- a/src/content/teibp.xsl
+++ b/src/content/teibp.xsl
@@ -302,8 +302,8 @@
 	 <head>
 	   <meta charset="UTF-8"/>
 	   
-	   <!--<link id="maincss" rel="stylesheet" type="text/css" href="{$teibpCSS}"/>-->
-	   <link id="mainless" rel="stylesheet/less" type="text/css" href="{$teibpLESS}"/>
+	   <link id="maincss" rel="stylesheet" type="text/css" href="{$teibpCSS}"/>
+	   <!--<link id="mainless" rel="stylesheet/less" type="text/css" href="{$teibpLESS}"/>-->
 	   <link id="customcss" rel="stylesheet" type="text/css" href="{$customCSS}"/>
 	   
 	   <xsl:call-template name="tagUsage2style"/>


### PR DESCRIPTION
The teibp.xsl was still linking to css/teibp.less, but it looks like the .less files were changed to .css files a while ago. I think maybe the wrong line was commented out. Now the teibp.xsl should link to css/teibp.css.

This change fixed the issue we were having getting the TEI boilerplate to render on a demo site 